### PR TITLE
Migrate dec/inf to gopkg.in/inf.v0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 
 go:
-  - 1.3
+  - 1.5
 
 before_install:
   - go get github.com/stretchr/testify/assert
   - go get github.com/cihub/seelog
   - export PATH=$PATH:/home/travis/gopath/bin:/usr/local/cassandra/bin
 
-install: 
+install:
   - go get -v .
 
 script:

--- a/cqlr_test.go
+++ b/cqlr_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/inf.v0"
 	"reflect"
-	"speter.net/go/exp/math/dec/inf"
 	"testing"
 	"time"
 )

--- a/test/kitchen_sink_test.go
+++ b/test/kitchen_sink_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/relops/cqlr"
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -51,7 +52,7 @@ func TestKitchenSink(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, count)
-	assert.Equal(t, k, nk)
+	assert.True(t, reflect.DeepEqual(k, nk))
 }
 
 func setup(t *testing.T, table string) *gocql.Session {

--- a/test/tmpl/kitchen_sink_data.go.tmpl
+++ b/test/tmpl/kitchen_sink_data.go.tmpl
@@ -5,7 +5,7 @@ package test
 import (
 	"time"
 	"github.com/gocql/gocql"
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 )
 
 {{ $inner := .types }}


### PR DESCRIPTION
`speter.net/go/exp/math/dec/inf` has been EOL'ed. This patch upgrades to `gopkg.in/inf.v0`.
